### PR TITLE
feat: add --nodes action input

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,7 +2,9 @@ name: "build-test"
 on: # rebuild any PRs and main branch changes
   pull_request:
     types:
-      [ opened, synchronize, reopened ]
+      - opened
+      - synchronize
+      - reopened
   schedule:
     # every 4 hours
     - cron: "0 */4 * * *"
@@ -10,6 +12,9 @@ on: # rebuild any PRs and main branch changes
     branches:
       - master
       - 'releases/*'
+defaults:
+  run:
+    shell: bash # set bash as default shell
 jobs:
   build: # make sure build/ci work properly
     runs-on: ubuntu-latest
@@ -42,6 +47,21 @@ jobs:
       # Test that minikube max-pods extraConfig has been set
       - run: |
           cat ~/.minikube/profiles/minikube/config.json | jq '.KubernetesConfig.ExtraOptions[0].Key' | grep max-pods
+  test-nodes:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+      - uses: ./
+        with:
+          nodes: 3
+      # Test that there are 3 minikube nodes
+      - run: |
+          if [ $(kubectl get nodes --no-headers | wc -l) -eq 3 ]; then
+            echo "The cluster has exactly 3 nodes."
+          else
+            echo "::error::The cluster does not have 3 nodes."
+            exit 1
+          fi
   test-insecure-registry:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -47,14 +47,14 @@ jobs:
       # Test that minikube max-pods extraConfig has been set
       - run: |
           cat ~/.minikube/profiles/minikube/config.json | jq '.KubernetesConfig.ExtraOptions[0].Key' | grep max-pods
-  test-nodes:
+  test-nodes: # make sure that action supports 'nodes' input
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
       - uses: ./
         with:
           nodes: 3
-      # Test that there are 3 minikube nodes
+      # Test that there are 3 minikube nodes after startup
       - run: |
           if [ $(kubectl get nodes --no-headers | wc -l) -eq 3 ]; then
             echo "The cluster has exactly 3 nodes."

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,5 +2,6 @@
     "files.exclude": {
         ".vscode": true,
         "node_modules": true
-    }
+    },
+    "makefile.configureOnOpen": false
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,6 +2,5 @@
     "files.exclude": {
         ".vscode": true,
         "node_modules": true
-    },
-    "makefile.configureOnOpen": false
+    }
 }

--- a/README.md
+++ b/README.md
@@ -91,6 +91,16 @@ By default setup-minikube caches the ISO, kicbase, and preload using GitHub Acti
 </details>
 
 <details>
+  <summary>nodes (optional)</summary>
+  <pre>
+    - default: '' (minikube will auto-set)
+    - options:
+      - '<number>'
+    - example: 4
+  </pre>
+</details>
+
+<details>
   <summary>cpus (optional)</summary>
   <pre>
     - default: '' (minikube will auto-set)

--- a/README.md
+++ b/README.md
@@ -299,6 +299,7 @@ jobs:
           driver: docker
           container-runtime: containerd
           kubernetes-version: v1.22.3
+          nodes: 2
           cpus: 4
           memory: 4000m
           cni: bridge

--- a/action.yml
+++ b/action.yml
@@ -66,7 +66,7 @@ inputs:
     required: false
     default: ''
   nodes:
-    decsription: 'The total number of nodes to spin up.'
+    description: 'The total number of nodes to spin up.'
     required: false
     default: ''
   install-path:

--- a/action.yml
+++ b/action.yml
@@ -65,6 +65,10 @@ inputs:
     description: 'Mount the source directory from your host into the target directory inside the cluster (format: <source directory>:<target directory>)'
     required: false
     default: ''
+  nodes:
+    decsription: 'The total number of nodes to spin up.'
+    required: false
+    default: ''
   install-path:
     description: 'Path where the executables (minikube) will get installed. Useful when having multiple self-hosted runners on one machine.'
     required: false

--- a/dist/index.js
+++ b/dist/index.js
@@ -212,6 +212,7 @@ const setArgs = (args) => {
         { key: 'memory', flag: '--memory' },
         { key: 'mount-path', flag: '--mount-string' },
         { key: 'network-plugin', flag: '--network-plugin' },
+        { key: 'nodes', flag: '--nodes' },
         { key: 'wait', flag: '--wait' },
     ];
     inputs.forEach((input) => {

--- a/src/inputs.ts
+++ b/src/inputs.ts
@@ -15,6 +15,7 @@ export const setArgs = (args: string[]) => {
     {key: 'memory', flag: '--memory'},
     {key: 'mount-path', flag: '--mount-string'},
     {key: 'network-plugin', flag: '--network-plugin'},
+    {key: 'nodes', flag: '--nodes'},
     {key: 'wait', flag: '--wait'},
   ]
   inputs.forEach((input) => {


### PR DESCRIPTION
# Background
Wanted the ability to specify `--nodes` upon minikube startup in a dedicated input block, instead of using `start-args:`. 

See original discussion [here](https://github.com/medyagh/setup-minikube/issues/698).

## What's Changed?

- Added a new input field for `nodes`
- Added workflow test to CI
- Updated readme docs